### PR TITLE
If there is no console extension, then use the default azure code sig…

### DIFF
--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -43,7 +43,7 @@ steps:
       toolMajorVersion: 'V2'
 
   - task: CodeSign@1
-    enabled: $(codeSignEnabled)
+    enabled: '$(codeSignEnabled)'
     inputs:
       Path: '$(Build.SourcesDirectory)\objects'
       verboseOutput: true

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -9,6 +9,7 @@ pool:
 
 variables:
   codeSignPolicyFile: ''
+  codeSignPolicyType: ''
 
 steps:
   - task: PowerShell@2
@@ -46,7 +47,7 @@ steps:
       Path: '$(Build.SourcesDirectory)\objects'
       verboseOutput: true
       Targets: '**.dll;**.exe;**sys'
-      PolicyType: 'Custom'
+      PolicyType: '$(codeSignPolicyType'
       PolicyFile: '$(codeSignPolicyFile)'
       ExcludePassesFromLog: false
 

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -43,7 +43,7 @@ steps:
       toolMajorVersion: 'V2'
 
   - task: CodeSign@1
-    enabled: '$(codeSignEnabled)'
+    condition: and(succeeded(), eq(variables['codeSignEnabled'], 'true'))
     inputs:
       Path: '$(Build.SourcesDirectory)\objects'
       verboseOutput: true

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -9,7 +9,7 @@ pool:
 
 variables:
   codeSignPolicyFile: ''
-  codeSignPolicyType: ''
+  codeSignPolicyType: 'Azure Security Pack'
 
 steps:
   - task: PowerShell@2

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -9,7 +9,7 @@ pool:
 
 variables:
   codeSignPolicyFile: ''
-  codeSignPolicyType: 'Azure Security Pack'
+  codeSignEnabled: false
 
 steps:
   - task: PowerShell@2
@@ -43,11 +43,12 @@ steps:
       toolMajorVersion: 'V2'
 
   - task: CodeSign@1
+    enabled: $(codeSignEnabled)
     inputs:
       Path: '$(Build.SourcesDirectory)\objects'
       verboseOutput: true
       Targets: '**.dll;**.exe;**sys'
-      PolicyType: '$(codeSignPolicyType)'
+      PolicyType: 'Custom'
       PolicyFile: '$(codeSignPolicyFile)'
       ExcludePassesFromLog: false
 

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -47,7 +47,7 @@ steps:
       Path: '$(Build.SourcesDirectory)\objects'
       verboseOutput: true
       Targets: '**.dll;**.exe;**sys'
-      PolicyType: '$(codeSignPolicyType'
+      PolicyType: '$(codeSignPolicyType)'
       PolicyFile: '$(codeSignPolicyFile)'
       ExcludePassesFromLog: false
 

--- a/tools/ExtensionDownloader.ps1
+++ b/tools/ExtensionDownloader.ps1
@@ -132,7 +132,7 @@ function Main
 
             $pFile  = ${env:Build_SourcesDirectory} + "\objects\ConsoleExtension\" + $objectInfo.codeSignPolicyFile;
             Write-Host "##vso[task.setvariable variable=codeSignPolicyFile;]$pFile"
-            Write-Host "##vso[task.setvariable variable=codeSignPolicyType]'Custom'"
+            Write-Host "##vso[task.setvariable variable=codeSignEnabled]true"
             $itemDir = $extensionRootDirectory + "\objects\consoleextension\" + $objectName;
             $cabFile = $itemDir + "\" + $objectName + ".cab"
 

--- a/tools/ExtensionDownloader.ps1
+++ b/tools/ExtensionDownloader.ps1
@@ -132,7 +132,7 @@ function Main
 
             $pFile  = ${env:Build_SourcesDirectory} + "\objects\ConsoleExtension\" + $objectInfo.codeSignPolicyFile;
             Write-Host "##vso[task.setvariable variable=codeSignPolicyFile;]$pFile"
-
+            Write-Host "##vso[task.setvariable variable=codeSignPolicyType]'Custom'"
             $itemDir = $extensionRootDirectory + "\objects\consoleextension\" + $objectName;
             $cabFile = $itemDir + "\" + $objectName + ".cab"
 


### PR DESCRIPTION
Noticed pull requests are failing for non console submissions when using custom code scan policy because we aren't supplying the policy xml. So, when it's not a console extension submission just use the default azure security pack policy.