### PR TITLE
trigger only on PR to master branch.

### DIFF
--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -1,7 +1,7 @@
 # Pipeline for running SDL scans
 # https://aka.ms/yaml
 
-trigger:
+pr:
 - master
 
 pool:

--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -1,6 +1,8 @@
 # Pipeline for running SDL scans
 # https://aka.ms/yaml
 
+trigger: none
+
 pr:
 - master
 


### PR DESCRIPTION
The previous trigger meant that pull requests and commits (when PR's were completed) were triggering the ADO pipline. We don't need them run in both instances and it won't succeed on the PR completed commit so only triggering the pipeline on the PR.